### PR TITLE
Swift 3 compatibility

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "a94323c"
-github "hkellaway/Gloss" "81b1aa6"
+github "Alamofire/Alamofire" ~> 4.0.1
+github "hkellaway/Gloss" ~> 1.0.0
 github "robbiehanson/CocoaAsyncSocket" ~> 7.4.3
-github "delba/Log" "ad3911f"
+github "delba/Log" "7dcb773"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "Alamofire/Alamofire" "a94323c6e556d47408b6186c948324b040d7ffc8"
+github "Alamofire/Alamofire" "4.0.1"
 github "robbiehanson/CocoaAsyncSocket" "7.5.0"
-github "hkellaway/Gloss" "81b1aa690aadb4f7c8020327069e13cf9f4c4fe8"
-github "delba/Log" "ad3911fed510c2d0cc1c3f047fcdf4632a73aa23"
+github "hkellaway/Gloss" "1.0.0"
+github "delba/Log" "7dcb773237d6e72c66e82eb744fb5eb379d64ceb"
 github "luisobo/Nocilla" "0.11.0"

--- a/Sources/Base/BridgeResourceModels/Rule/Rule.swift
+++ b/Sources/Base/BridgeResourceModels/Rule/Rule.swift
@@ -39,7 +39,7 @@ public class Rule: BridgeResource, BridgeResourceDictGenerator {
             Log.error("Can't create Rule, missing required attribute \"name\" in JSON:\n \(json)"); return nil
         }
         
-        guard let created: NSDate = Decoder.decodeDate("created", dateFormatter:dateFormatter)(json) else {
+        guard let created: Date = Decoder.decode(dateForKey:"created", dateFormatter:dateFormatter)(json) else {
             Log.error("Can't create Rule, missing required attribute \"created\" in JSON:\n \(json)"); return nil
         }
         
@@ -67,12 +67,12 @@ public class Rule: BridgeResource, BridgeResourceDictGenerator {
         self.identifier = identifier
         self.name = name
         self.created = created as Date
-        self.lasttriggered = Decoder.decodeDate("lasttriggered", dateFormatter:dateFormatter)(json)
+        self.lasttriggered = Decoder.decode(dateForKey:"lasttriggered", dateFormatter:dateFormatter)(json)
         self.timestriggered = timestriggered
         self.owner = owner
         self.status = status
-        self.conditions = [RuleCondition].fromJSONArray(conditionJSONs)!
-        self.actions = [RuleAction].fromJSONArray(actionJSONs)!
+        self.conditions = [RuleCondition].from(jsonArray: conditionJSONs)!
+        self.actions = [RuleAction].from(jsonArray: actionJSONs)!
     }
     
     public func toJSON() -> JSON? {
@@ -82,8 +82,8 @@ public class Rule: BridgeResource, BridgeResourceDictGenerator {
         let json = jsonify([
             "id" ~~> self.identifier,
             "name" ~~> self.name,
-            Encoder.encodeDate("created", dateFormatter: dateFormatter)(self.created),
-            Encoder.encodeDate("lasttriggered", dateFormatter: dateFormatter)(self.lasttriggered),
+            Encoder.encode(dateForKey:"created", dateFormatter: dateFormatter)(self.created),
+            Encoder.encode(dateForKey:"lasttriggered", dateFormatter: dateFormatter)(self.lasttriggered),
             "timestriggered" ~~> self.timestriggered,
             "owner" ~~> self.owner,
             "status" ~~> self.status,

--- a/Sources/Base/BridgeResourceModels/Rule/RuleAction.swift
+++ b/Sources/Base/BridgeResourceModels/Rule/RuleAction.swift
@@ -31,7 +31,7 @@ public class RuleAction: Decodable, Encodable {
         
         self.address = address
         self.method = method
-        self.body = body
+        self.body = body as NSDictionary
     }
     
     public func toJSON() -> JSON? {

--- a/Sources/Base/BridgeResourceModels/Rule/RuleCondition.swift
+++ b/Sources/Base/BridgeResourceModels/Rule/RuleCondition.swift
@@ -17,7 +17,7 @@ public enum RuleConditionOperator: String {
 public class RuleCondition: Decodable, Encodable  {
     
     public let address: String
-    public let conditionOperator: RuleConditionOperator
+    public let conditionOperator: RuleConditionOperator?
     public let value: String?
     
     public required init?(json: JSON) {
@@ -26,13 +26,13 @@ public class RuleCondition: Decodable, Encodable  {
             Log.error("Can't create RuleCondition, missing required attribute \"address\" in JSON:\n \(json)"); return nil
         }
         
-        guard let conditionOperator: RuleConditionOperator = "operator" <~~ json else {
-            Log.error("Can't create RuleCondition, missing required attribute \"operator\" in JSON:\n \(json)"); return nil
-        }
+//        guard let conditionOperator: RuleConditionOperator = "operator" <~~ json else {
+//            Log.error("Can't create RuleCondition, missing required attribute \"operator\" in JSON:\n \(json)"); return nil
+//        }
         
         self.address = address
-        self.conditionOperator = conditionOperator
         
+        self.conditionOperator = "operator" <~~ json
         self.value = "value" <~~ json
     }
     

--- a/Sources/Base/BridgeResourceModels/Scene.swift
+++ b/Sources/Base/BridgeResourceModels/Scene.swift
@@ -109,7 +109,7 @@ public class PartialScene: BridgeResource, BridgeResourceDictGenerator {
         let dateFormatter = DateFormatter.hueApiDateFormatter
         
         self.appData = "appdata" <~~ json
-        lastUpdated = Decoder.decodeDate("lastupdated", dateFormatter:dateFormatter)(json)
+        lastUpdated = Decoder.decode(dateForKey:"lastupdated", dateFormatter:dateFormatter)(json)
     }
     
     public func toJSON() -> JSON? {
@@ -124,7 +124,7 @@ public class PartialScene: BridgeResource, BridgeResourceDictGenerator {
             "recycle" ~~> recycle,
             "locked" ~~> locked,
             "appdata" ~~> appData,
-            Encoder.encodeDate("lastupdated", dateFormatter: dateFormatter)(lastUpdated),
+            Encoder.encode(dateForKey: "lastupdated", dateFormatter: dateFormatter)(lastUpdated),
             "version" ~~> version
             ])
         

--- a/Sources/Base/BridgeResourceModels/Schedule/ScheduleCommand.swift
+++ b/Sources/Base/BridgeResourceModels/Schedule/ScheduleCommand.swift
@@ -31,7 +31,7 @@ public class ScheduleCommand: Decodable, Encodable {
         
         self.address = address
         self.method = method
-        self.body = body
+        self.body = body as NSDictionary
     }
     
     public func toJSON() -> JSON? {

--- a/Sources/Base/BridgeResourceModels/Sensors/SensorState.swift
+++ b/Sources/Base/BridgeResourceModels/Sensors/SensorState.swift
@@ -108,7 +108,7 @@ public class PartialSensorState: Decodable, Encodable, Equatable {
         
         let dateFormatter = DateFormatter.hueApiDateFormatter
         
-        lastUpdated = Decoder.decodeDate("lastupdated", dateFormatter:dateFormatter)(json)
+        lastUpdated = Decoder.decode(dateForKey: "lastupdated", dateFormatter:dateFormatter)(json)
     }
     
     public func toJSON() -> JSON? {
@@ -116,7 +116,7 @@ public class PartialSensorState: Decodable, Encodable, Equatable {
         let dateFormatter = DateFormatter.hueApiDateFormatter
         
         let json = jsonify([
-            Encoder.encodeDate("lastupdated", dateFormatter: dateFormatter)(lastUpdated)
+            Encoder.encode(dateForKey: "lastupdated", dateFormatter: dateFormatter)(lastUpdated)
             ])
         
         return json

--- a/Sources/Base/BridgeResourceModels/WhitelistEntry.swift
+++ b/Sources/Base/BridgeResourceModels/WhitelistEntry.swift
@@ -44,8 +44,8 @@ public struct WhitelistEntry: BridgeResource, BridgeResourceDictGenerator {
         
         guard let identifier: String = "id" <~~ json,
             let name: String = "name" <~~ json,
-            let lastUseDate: NSDate = Decoder.decodeDate("last use date", dateFormatter:dateFormatter)(json),
-            let createDate: NSDate = Decoder.decodeDate("create date", dateFormatter: dateFormatter)(json)
+            let lastUseDate: Date = Decoder.decode(dateForKey: "last use date", dateFormatter:dateFormatter)(json),
+            let createDate: Date = Decoder.decode(dateForKey:"create date", dateFormatter: dateFormatter)(json)
             else { return nil }
         
         self.identifier = identifier
@@ -62,8 +62,8 @@ public struct WhitelistEntry: BridgeResource, BridgeResourceDictGenerator {
         let json = jsonify([
             "id" ~~> identifier,
             "name" ~~> name,
-            Encoder.encodeDate("last use date", dateFormatter: dateFormatter)(lastUseDate),
-            Encoder.encodeDate("create date", dateFormatter: dateFormatter)(createDate)
+            Encoder.encode(dateForKey: "last use date", dateFormatter: dateFormatter)(lastUseDate),
+            Encoder.encode(dateForKey: "create date", dateFormatter: dateFormatter)(createDate)
             ])
         
         return json

--- a/Sources/Base/BridgeSendAPI.swift
+++ b/Sources/Base/BridgeSendAPI.swift
@@ -13,7 +13,7 @@ import Gloss
 public class BridgeSendAPI {
   
     //    public typealias PHBridgeSendDictionaryCompletionHandler = (dictionary: [String: AnyObject], errors: [Error]?) -> Void
-    public typealias BridgeSendErrorArrayCompletionHandler = (errors: [Error]?) -> Void
+    public typealias BridgeSendErrorArrayCompletionHandler = (_ errors: [Error]?) -> Void
     
     private var bridgeAccessConfig: BridgeAccessConfig?;
     
@@ -28,78 +28,78 @@ public class BridgeSendAPI {
     
     // MARK: Scenes
     
-    public func recallSceneWithIdentifier(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func recallSceneWithIdentifier(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         let parameters = ["scene": identifier]
         
         guard let bridgeAccessConfig = bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups/0/action"
-
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        
+        Alamofire.request(url, method: .get, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
 
     }
     
-    public func recallSceneWithIdentifier(_ identifier: String, inGroupWithIdentifier groupIdentifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func recallSceneWithIdentifier(_ identifier: String, inGroupWithIdentifier groupIdentifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = bridgeAccessConfig else{
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
         let parameters = ["scene": identifier]
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups/\(groupIdentifier)/action"
 
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
     /**
      Creates the given scene with all lights in the provided lights resource. For a given scene the current light settings of the given lights resources are stored. If the scene id is recalled in the future, these light settings will be reproduced on these lamps. If an existing name is used then the settings for this scene will be overwritten and the light states resaved. The bridge can support up to 200 scenes, however please also note there is a maximum of 2048 scene lightstates so for example, of all your scenes have 20 lightstates, the maximum number of allowed scenes will be 102.
      */
-    public func createSceneWithName(_ name: String, inlcudeLightIds lightIds: [String], recycle: Bool = false, transitionTime: Int? = nil, picture: String? = nil, appData: AppData? = nil, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func createSceneWithName(_ name: String, inlcudeLightIds lightIds: [String], recycle: Bool = false, transitionTime: Int? = nil, picture: String? = nil, appData: AppData? = nil, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = bridgeAccessConfig else{
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters: [String: AnyObject] = ["name": name, "lights": lightIds, "recycle": recycle];
+        var parameters: [String: Any] = ["name": name, "lights": lightIds, "recycle": recycle];
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/scenes"
 
         parameters["transitiontime"] = transitionTime
         parameters["picture"] = picture
         parameters["appdata"] = appData?.toJSON()
 
-        Alamofire.request(.POST, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
 
     }
     
-    public func removeSceneWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeSceneWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
 
         remove(.scene, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
     // MARK: Lights
     
-    public func updateLightStateForId(_ identifier: String, withLightState lightState: LightState, transitionTime: Int? = nil, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func updateLightStateForId(_ identifier: String, withLightState lightState: LightState, transitionTime: Int? = nil, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
@@ -111,76 +111,76 @@ public class BridgeSendAPI {
 
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/lights/\(identifier)/state"
 
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
-    public func removeLightWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeLightWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.light, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
     // MARK: Groups
     
-    public func createRoomWithName(_ name: String, andType type: GroupType, andRoomClass roomClass: RoomClass, inlcudeLightIds lightIds: [String], completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func createRoomWithName(_ name: String, andType type: GroupType, andRoomClass roomClass: RoomClass, inlcudeLightIds lightIds: [String], completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        let parameters: [String: AnyObject] = ["name": name, "class": roomClass.rawValue, "type": type.rawValue
+        let parameters: [String: Any] = ["name": name, "class": roomClass.rawValue, "type": type.rawValue
             , "lights": lightIds]
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups"
         
-        Alamofire.request(.POST, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
 
     }
     
-    public func createGroupWithName(_ name: String, andType type: GroupType, inlcudeLightIds lightIds: [String], completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func createGroupWithName(_ name: String, andType type: GroupType, inlcudeLightIds lightIds: [String], completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        let parameters: [String: AnyObject] = ["name": name, "type": type.rawValue
+        let parameters: [String: Any] = ["name": name, "type": type.rawValue
             , "lights": lightIds]
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups"
 
-        Alamofire.request(.POST, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
     /** 
      Allows the user to modify the name and the lights of a group
     */
-    public func updateGroupWithId(_ identifier: String, newName: String?, newLightIdentifiers: [String]?, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func updateGroupWithId(_ identifier: String, newName: String?, newLightIdentifiers: [String]?, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups/\(identifier)"
         parameters["name"] = newName;
         parameters["lights"] = newLightIdentifiers;
         
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
 
     }
@@ -188,190 +188,189 @@ public class BridgeSendAPI {
     /**
      Allows the user to modify the name and the lights of a group
      */
-    public func updateRoomWithId(_ identifier: String, newName: String?, newLightIdentifiers: [String]?, newRoomClass: RoomClass?, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func updateRoomWithId(_ identifier: String, newName: String?, newLightIdentifiers: [String]?, newRoomClass: RoomClass?, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else{
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups/\(identifier)"
 
         parameters["name"] = newName;
         parameters["class"] = newRoomClass?.rawValue;
         parameters["lights"] = newLightIdentifiers;
         
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
-    public func removeGroupWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeGroupWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.group, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
-    public func setLightStateForGroupWithId(_ identifier: String, withLightState lightState: LightState, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func setLightStateForGroupWithId(_ identifier: String, withLightState lightState: LightState, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else{
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
         let parameters = lightState.toJSON()!
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/groups/\(identifier)/action"
         
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
     // MARK: Rules
     
-    public func createRuleWithName(_ name: String, andConditions conditions: [RuleCondition], andActions actions: [RuleAction], completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func createRuleWithName(_ name: String, andConditions conditions: [RuleCondition], andActions actions: [RuleAction], completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/rules"
 
         parameters["name"] = name;
         parameters["conditions"] = conditions.toJSONArray();
         parameters["actions"] = actions.toJSONArray();
         
-        Alamofire.request(.POST, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
 
     }
     
-    public func updateRuleWithId(_ identifier: String, newName: String, newConditions: [RuleCondition]?, newActions: [RuleAction]?, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func updateRuleWithId(_ identifier: String, newName: String, newConditions: [RuleCondition]?, newActions: [RuleAction]?, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/rules/\(identifier)"
         
         parameters["name"] = newName;
         parameters["conditions"] = newConditions?.toJSONArray();
         parameters["actions"] = newActions?.toJSONArray();
         
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
-    public func removeRuleWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeRuleWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.rule, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
     // MARK: Schedules
     
-    public func createScheduleWithName(_ name: String, andCommand command: ScheduleCommand, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func createScheduleWithName(_ name: String, andCommand command: ScheduleCommand, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/schedules"
         
         parameters["name"] = name;
         parameters["command"] = command.toJSON();
         
-        Alamofire.request(.POST, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
-    public func updateScheduleWithId(_ identifier: String, newName: String, newCommand: ScheduleCommand, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func updateScheduleWithId(_ identifier: String, newName: String, newCommand: ScheduleCommand, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
-        var parameters = [String: AnyObject]()
+        var parameters = [String: Any]()
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/schedules/\(identifier)"
 
         parameters["name"] = newName;
         parameters["command"] = newCommand.toJSON();
         
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-                completionHandler(errors: self.errorsFromResponse(response))
+                completionHandler(self.errorsFromResponse(response))
         }
     }
     
-    public func removeScheduleWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeScheduleWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.schedule, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
     // MARK: Sensors
     
-    public func removeSensorWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeSensorWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.sensor, withIdentifier: identifier, completionHandler: completionHandler)
     }
     
     // MARK: Whitelist Entry
     
-    public func removeWhitelistEntryWithId(_ identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    public func removeWhitelistEntryWithId(_ identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         remove(.whitelistEntry, withIdentifier: identifier, completionHandler: completionHandler)
     }
 
     // MARK: Helpers
     
-    private func errorsFromResponse(_ response: Response<AnyObject, NSError>) -> [Error]? {
+    private func errorsFromResponse(_ response: DataResponse<Any>) -> [Error]? {
         
         var errors: [Error]?
         if let responseItemJSONs = response.result.value as? [JSON] {
-            
-            errors = [Error].fromJSONArray(responseItemJSONs)
+            errors = [Error].from(jsonArray: responseItemJSONs)
         }
         
-        return errors?.count > 0 ? errors : nil
+        return (errors?.count)! > 0 ? errors : nil
     }
     
-    private func remove(_ bridgeResourceType: BridgeResourceType, withIdentifier identifier: String, completionHandler: BridgeSendErrorArrayCompletionHandler) {
+    private func remove(_ bridgeResourceType: BridgeResourceType, withIdentifier identifier: String, completionHandler: @escaping BridgeSendErrorArrayCompletionHandler) {
         
         let resourceTypeForURL = bridgeResourceType == .whitelistEntry
                                  ? "config/whitelist"
                                  : "\(bridgeResourceType)s"
 
         guard let bridgeAccessConfig = self.bridgeAccessConfig else {
-            completionHandler(errors: [Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
+            completionHandler([Error(address: "SwiftyHue", errorDescription: "No bridgeAccessConfig available", type: 1)!])
             return
         }
 
         let url = "http://\(bridgeAccessConfig.ipAddress)/api/\(bridgeAccessConfig.username)/\(resourceTypeForURL)/\(identifier)"
 
-        Alamofire.request(.DELETE, url, encoding: .json)
+        Alamofire.request(url, method: .delete, encoding: JSONEncoding.default)
             .responseJSON { response in
                 
-            completionHandler(errors: self.errorsFromResponse(response))
+            completionHandler(self.errorsFromResponse(response))
         }
     }
     

--- a/Sources/Base/HeartbeatManager.swift
+++ b/Sources/Base/HeartbeatManager.swift
@@ -91,26 +91,26 @@ public class HeartbeatManager {
 
         Log.trace("Heartbeat Request", "\(url)")
         
-        Alamofire.request(.GET, url)
-            .responseJSON { response in
+        Alamofire.request(url).responseJSON { response in // method
+            
+            switch response.result {
+            case .success:
                 
-                switch response.result {
-                case .success:
-                    
-                    self.handleSuccessResponseResult(response.result, resourceType: resourceType)
-                    self.notifyAboutLocalConnection()
-                    
-                case .failure(let error):
-                    
-                    self.notifyAboutNoLocalConnection()
-                    Log.trace("Heartbeat Request Error: ", error)
-                }
+                self.handleSuccessResponseResult(response.result, resourceType: resourceType)
+                self.notifyAboutLocalConnection()
+                
+            case .failure(let error):
+                
+                self.notifyAboutNoLocalConnection()
+                Log.trace("Heartbeat Request Error: ", error)
+            }
+            
         }
     }
     
     // MARK: Timer Action Response Handling
     
-    private func handleSuccessResponseResult(_ result: Result<AnyObject, NSError>, resourceType: HeartbeatBridgeResourceType) {
+    private func handleSuccessResponseResult(_ result: Result<Any>, resourceType: HeartbeatBridgeResourceType) {
         
         Log.trace("Heartbeat Response for Resource Type \(resourceType.rawValue.lowercased()) received")
         //Log.trace("Heartbeat Response: \(resourceType.rawValue.lowercaseString): ", result.value)
@@ -137,7 +137,7 @@ public class HeartbeatManager {
         
     }
     
-    private func responseResultIsPhilipsAPIErrorType(result: Result<AnyObject, NSError>, resourceType: HeartbeatBridgeResourceType) -> Bool {
+    private func responseResultIsPhilipsAPIErrorType(result: Result<Any>, resourceType: HeartbeatBridgeResourceType) -> Bool {
         
         switch resourceType {
             

--- a/Sources/Base/ResourceCacheHeartbeatProcessor.swift
+++ b/Sources/Base/ResourceCacheHeartbeatProcessor.swift
@@ -197,19 +197,19 @@ class ResourceCacheHeartbeatProcessor: HeartbeatProcessor {
         switch resourceType {
             
         case .lights:
-            return Light.dictionaryFromResourcesJSON(json)
+            return Light.dictionaryFromResourcesJSON(json) as NSDictionary
         case .groups:
-            return Group.dictionaryFromResourcesJSON(json)
+            return Group.dictionaryFromResourcesJSON(json) as NSDictionary
         case .scenes:
-            return PartialScene.dictionaryFromResourcesJSON(json)
+            return PartialScene.dictionaryFromResourcesJSON(json) as NSDictionary
         case .config:
             break;
         case .schedules:
-            return Schedule.dictionaryFromResourcesJSON(json)
+            return Schedule.dictionaryFromResourcesJSON(json) as NSDictionary
         case .sensors:
-            return Sensor.dictionaryFromResourcesJSON(json)
+            return Sensor.dictionaryFromResourcesJSON(json) as NSDictionary
         case .rules:
-            return Rule.dictionaryFromResourcesJSON(json)
+            return Rule.dictionaryFromResourcesJSON(json) as NSDictionary
         }
         
         return [:]

--- a/Sources/Base/TestRequester.swift
+++ b/Sources/Base/TestRequester.swift
@@ -53,7 +53,7 @@ public class TestRequester {
         let parameters = lightState.toJSON()!
         let url = "http://\(bridgeIp)/api/\(bridgeAcc)/groups/1/action"
 
-        Alamofire.request(.PUT, url, parameters: parameters, encoding: .json)
+        Alamofire.request(url, method: .put, parameters: parameters, encoding: JSONEncoding.default)
             .responseJSON { response in
         
                 print(response)
@@ -134,7 +134,8 @@ public class TestRequester {
 //    }
     
     public func requestGroups() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/groups", parameters: nil)
+        
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/groups", parameters: nil)
         .responseJSON { response in
             
             if let resultValueJSON = response.result.value as? JSON {
@@ -150,7 +151,7 @@ public class TestRequester {
     }
     
     public func requestScenes() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/scenes", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/scenes", parameters: nil)
             .responseJSON { response in
                 
                 if let resultValueJSON = response.result.value as? JSON {
@@ -166,7 +167,7 @@ public class TestRequester {
     }
     
     public func requestRules() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/rules", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/rules", parameters: nil)
             .responseJSON { response in
                 
                 if let resultValueJSON = response.result.value as? JSON {
@@ -198,7 +199,7 @@ public class TestRequester {
 //    }
     
     public func requestSchedules() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/schedules", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/schedules", parameters: nil)
             .responseJSON { response in
                 
                 if let resultValueJSON = response.result.value as? JSON {
@@ -215,7 +216,7 @@ public class TestRequester {
     
     public func requestBridgeConfiguration() {
         
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/config", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/config", parameters: nil)
             .responseJSON { response in
                 
                 if let resultValueJSON = response.result.value as? JSON {
@@ -227,7 +228,7 @@ public class TestRequester {
     }
     
     public func requestLights() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/lights", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/lights", parameters: nil)
             .responseJSON { response in
                 
             if let resultValueJSON = response.result.value as? JSON {
@@ -239,12 +240,12 @@ public class TestRequester {
     }
     
     public func requestError() {
-        Alamofire.request(.GET, "http://\(bridgeIp)/api/\(bridgeAcc)/giveMeAError", parameters: nil)
+        Alamofire.request("http://\(bridgeIp)/api/\(bridgeAcc)/giveMeAError", parameters: nil)
             .responseJSON { response in
                 
                 if let resultValueJSON = response.result.value as? [JSON] {
                     
-                    let errors = [Error].fromJSONArray(resultValueJSON)
+                    let errors = [Error].from(jsonArray: resultValueJSON)
                     print(errors)
                 }
         }
@@ -254,11 +255,11 @@ public class TestRequester {
         
         if let JSON = resourcesDict as? NSMutableDictionary {
             
-            var resourceJSONs = [[String: AnyObject]]();
+            var resourceJSONs = [[String: Any]]();
             
             for item in JSON {
                 
-                var resourceJSON = item.value as! [String: AnyObject];
+                var resourceJSON = item.value as! [String: Any];
                 resourceJSON["id"] = item.key;
                 
                 resourceJSONs.append(resourceJSON)

--- a/Sources/BridgeServices/BridgeAuthenticator/BridgeAuthenticator.swift
+++ b/Sources/BridgeServices/BridgeAuthenticator/BridgeAuthenticator.swift
@@ -49,11 +49,21 @@ public class BridgeAuthenticator {
     }
 
     @objc private func startRequest() {
+        
         let request = createRequest()
-
+        
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-            self.handleResponse(data, response: response, error: error)
+            self.handleResponse(data, response: response, error: error as NSError?)
+            return ()
         }
+        
+//        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+//            self.handleResponse(data, response: response, error: error)
+//        }
+        
+//        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+//            self.handleResponse(data, response: response, error: error)
+//        }
 
         task.resume()
     }
@@ -104,16 +114,17 @@ public class BridgeAuthenticator {
             return NSError(domain: "BridgeAuthenticator", code: 404, userInfo: [NSLocalizedDescriptionKey: "Could not authenticate user (no data)"])
         }
 
-        guard let result = try? JSONSerialization.jsonObject(with: data, options: []) else {
+        guard let result = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] else {
             return NSError(domain: "BridgeAuthenticator", code: 500, userInfo: [NSLocalizedDescriptionKey: "Could not parse result."])
         }
 
-        guard let errorJson = result[0]["error"] as? [String: AnyObject] else {
+        guard let errorJson = result?[0]["error"] as? [String: Any] else {
             return nil
         }
 
         let desc = errorJson["description"] as! String
         let error = NSError(domain: "BridgeAuthenticator", code: errorJson["type"] as! Int, userInfo: [NSLocalizedDescriptionKey: desc])
+        
         return error
     }
 

--- a/Sources/BridgeServices/BridgeFinder/Validator/BridgeResultParser.swift
+++ b/Sources/BridgeServices/BridgeFinder/Validator/BridgeResultParser.swift
@@ -12,8 +12,8 @@ class BridgeResultParser: NSObject, XMLParserDelegate {
     private let parser: XMLParser
     private var element: String = ""
     private var bridge: HueBridge?
-    private var successBlock: ((bridge: HueBridge) -> Void)?
-    private var failureBlock: ((error: NSError) -> Void)?
+    private var successBlock: ((_ bridge: HueBridge) -> Void)?
+    private var failureBlock: ((_ error: NSError) -> Void)?
 
     private var urlBase: String = ""
     private var ip: String = ""
@@ -35,7 +35,7 @@ class BridgeResultParser: NSObject, XMLParserDelegate {
         parser.delegate = self
     }
 
-    func parse(_ success: (bridge: HueBridge) -> Void, failure: (error: NSError) -> Void) {
+    func parse(_ success: @escaping (_ bridge: HueBridge) -> Void, failure: @escaping (_ error: NSError) -> Void) {
         self.successBlock = success
         self.failureBlock = failure
 
@@ -45,7 +45,7 @@ class BridgeResultParser: NSObject, XMLParserDelegate {
     private func cancelWithError(_ errorMessage: String) {
         parser.abortParsing()
         if let failureBlock = failureBlock {
-            failureBlock(error: NSError(domain: "HueBridgeParser", code: 500, userInfo: [NSLocalizedDescriptionKey: errorMessage]))
+            failureBlock(NSError(domain: "HueBridgeParser", code: 500, userInfo: [NSLocalizedDescriptionKey: errorMessage]))
         }
     }
 
@@ -117,7 +117,7 @@ class BridgeResultParser: NSObject, XMLParserDelegate {
 
     public func parserDidEndDocument(_ parser: XMLParser) {
         if let successBlock = successBlock, let bridge = bridge {
-            successBlock(bridge: bridge)
+            successBlock(bridge)
         }
     }
 

--- a/Sources/BridgeServices/BridgeFinder/Validator/BridgeValidator.swift
+++ b/Sources/BridgeServices/BridgeFinder/Validator/BridgeValidator.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 class BridgeValidator {
-    func validate(_ ip: String, success: (bridge: HueBridge) -> Void, failure: (error: NSError) -> Void) {
+    func validate(_ ip: String, success: @escaping (_ bridge: HueBridge) -> Void, failure: @escaping (_ error: NSError) -> Void) {
         let request = createRequest(ip)
         startRequest(request as URLRequest, success: success, failure: failure)
     }
@@ -25,15 +25,15 @@ class BridgeValidator {
         return request
     }
 
-    private func startRequest(_ request: URLRequest, success: (bridge: HueBridge) -> Void, failure: (error: NSError) -> Void) {
+    private func startRequest(_ request: URLRequest, success: @escaping (_ bridge: HueBridge) -> Void, failure: @escaping (_ error: NSError) -> Void) {
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
             if let error = error {
-                failure(error: error)
+                failure(error as NSError)
                 return
             }
 
             guard let data = data else {
-                failure(error: NSError(domain: "HueBridgeValidator", code: 500, userInfo: [NSLocalizedDescriptionKey: "No data from bridge received."]))
+                failure(NSError(domain: "HueBridgeValidator", code: 500, userInfo: [NSLocalizedDescriptionKey: "No data from bridge received."]))
                 return
             }
 

--- a/SwiftyHue Example Watch Extension/InterfaceController.swift
+++ b/SwiftyHue Example Watch Extension/InterfaceController.swift
@@ -12,11 +12,11 @@ import Foundation
 
 class InterfaceController: WKInterfaceController {
 
-    override func awakeWithContext(context: AnyObject?) {
-        super.awakeWithContext(context)
-        
-        // Configure interface objects here.
-    }
+//    override func awakeWithContext(context: AnyObject?) {
+//        super.awake(withContext: context)
+//        
+//        // Configure interface objects here.
+//    }
 
     override func willActivate() {
         // This method is called when watch view controller is about to be visible to user

--- a/SwiftyHue Example/Base.lproj/Main.storyboard
+++ b/SwiftyHue Example/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="zTB-qt-jUJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="zTB-qt-jUJ">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Bridge Selection Table View Controller-->
@@ -11,15 +12,15 @@
             <objects>
                 <tableViewController id="RMj-oX-xYu" customClass="BridgeSelectionTableViewController" customModule="SwiftyHue_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="zaA-tF-htt">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BridgeCell" id="lm6-A5-anc">
-                                <rect key="frame" x="0.0" y="92" width="600" height="44"/>
+                                <rect key="frame" x="0.0" y="92" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lm6-A5-anc" id="hVs-Jc-M7N">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <frame key="frameInset" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -47,18 +48,18 @@
                         <viewControllerLayoutGuide type="bottom" id="Qlj-EV-AbR"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ecv-62-62S">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PressSmartbridgeV2" translatesAutoresizingMaskIntoConstraints="NO" id="SFD-rz-HBh">
-                                <rect key="frame" x="190" y="200" width="220" height="200"/>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="PressSmartbridgeV2" translatesAutoresizingMaskIntoConstraints="NO" id="SFD-rz-HBh">
+                                <frame key="frameInset" minX="190" minY="200" width="220" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="UNq-EB-Hl3"/>
                                     <constraint firstAttribute="width" constant="220" id="zEH-hq-1OZ"/>
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="SFD-rz-HBh" firstAttribute="centerY" secondItem="ecv-62-62S" secondAttribute="centerY" id="2hM-0u-Sci"/>
                             <constraint firstItem="SFD-rz-HBh" firstAttribute="centerX" secondItem="ecv-62-62S" secondAttribute="centerX" id="Z4W-Sz-uLh"/>
@@ -81,68 +82,57 @@
                         <viewControllerLayoutGuide type="bottom" id="sAd-ob-32U"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Me1-wC-Fkq">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="7hK-md-ZyA">
-                                <rect key="frame" x="150" y="64" width="300" height="536"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="7hK-md-ZyA">
+                                <frame key="frameInset" minX="150" minY="64" width="300" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bridge Access Created" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3cY-Ra-QIo">
-                                        <rect key="frame" x="0.0" y="0.0" width="300" height="179"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="9Gb-Zm-MWk">
-                                        <rect key="frame" x="0.0" y="179" width="300" height="179"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="CuN-d5-BMI">
-                                                <rect key="frame" x="0.0" y="0.0" width="300" height="60"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" misplaced="YES" text="IP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vGj-us-uim">
-                                                        <rect key="frame" x="0.0" y="0.0" width="16" height="60"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="IP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vGj-us-uim">
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" misplaced="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="H8U-YH-ebi">
-                                                        <rect key="frame" x="36" y="0.0" width="265" height="60"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="H8U-YH-ebi">
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7GJ-Ut-mU1">
-                                                <rect key="frame" x="0.0" y="60" width="300" height="60"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="BRIDGE ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hgu-Jy-1rD">
-                                                        <rect key="frame" x="0.0" y="0.0" width="82" height="60"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="tTJ-UV-0zl">
-                                                        <rect key="frame" x="102" y="0.0" width="198" height="60"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="vcd-IL-Xr3">
-                                                <rect key="frame" x="0.0" y="120" width="300" height="60"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="USER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fs7-zv-qJc">
-                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="60"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="OMw-2k-S44">
-                                                        <rect key="frame" x="64" y="0.0" width="236" height="60"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
@@ -150,10 +140,9 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yHs-4S-C4K">
-                                        <rect key="frame" x="0.0" y="358" width="300" height="179"/>
                                         <state key="normal" title="Ok"/>
                                         <connections>
-                                            <action selector="okButtonTapped:" destination="8wT-Ab-9br" eventType="touchUpInside" id="oDg-OY-Cul"/>
+                                            <action selector="okButtonTapped:" destination="8wT-Ab-9br" eventType="touchUpInside" id="dib-D2-h4A"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -174,7 +163,7 @@
                                 </variation>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="7hK-md-ZyA" firstAttribute="centerX" secondItem="Me1-wC-Fkq" secondAttribute="centerX" id="2iY-Jz-Ulk"/>
                             <constraint firstItem="7hK-md-ZyA" firstAttribute="centerX" secondItem="Me1-wC-Fkq" secondAttribute="centerX" id="JrN-a6-g0M"/>
@@ -212,56 +201,49 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jHM-aR-G6a">
-                                <rect key="frame" x="20" y="20" width="560" height="536"/>
+                                <frame key="frameInset" minX="20" minY="20" width="343" height="603"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ahA-3W-UB1" userLabel="Config">
-                                        <rect key="frame" x="233" y="0.0" width="95" height="77"/>
                                         <state key="normal" title="Bridge Config"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="ConfigSegue" id="wXY-Hb-Acw"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1tV-Of-ikt">
-                                        <rect key="frame" x="259" y="77" width="43" height="77"/>
                                         <state key="normal" title="Lights"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="LightsSegue" id="EDU-bu-f2u"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FfQ-s6-cOi">
-                                        <rect key="frame" x="255" y="153" width="50" height="77"/>
                                         <state key="normal" title="Groups"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="GroupsSegue" id="hxa-GC-vGO"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iV5-U8-7lq">
-                                        <rect key="frame" x="255" y="230" width="51" height="77"/>
                                         <state key="normal" title="Scenes"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="ScenesSegue" id="WAx-xf-bFO"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G1O-Z9-Pso">
-                                        <rect key="frame" x="261" y="307" width="38" height="77"/>
                                         <state key="normal" title="Rules"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="RulesSegue" id="FVd-Sc-lbY"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uh2-sS-XRt" userLabel="Schedules">
-                                        <rect key="frame" x="244" y="383" width="72" height="77"/>
                                         <state key="normal" title="Schedules"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="SchedulesSegue" id="Osh-ja-QfE"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mUA-cy-r8U" userLabel="Sensors">
-                                        <rect key="frame" x="252" y="460" width="56" height="77"/>
                                         <state key="normal" title="Sensors"/>
                                         <connections>
                                             <segue destination="z0t-nY-6dU" kind="show" identifier="SensorsSegue" id="Ylm-za-aso"/>
@@ -270,7 +252,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="jHM-aR-G6a" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="Oau-wA-rwV"/>
                             <constraint firstItem="jHM-aR-G6a" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" id="dAb-de-AqB"/>
@@ -289,15 +271,15 @@
             <objects>
                 <tableViewController id="z0t-nY-6dU" customClass="BridgeResourceTableViewController" customModule="SwiftyHue_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="mEU-2C-yEt">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BridgeResourceTableViewCell" id="2xf-fm-iLi">
-                                <rect key="frame" x="0.0" y="92" width="600" height="44"/>
+                                <rect key="frame" x="0.0" y="92" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2xf-fm-iLi" id="GNH-00-nXj">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <frame key="frameInset" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>

--- a/SwiftyHue Example/BridgeAccessConfigPresentationViewController.swift
+++ b/SwiftyHue Example/BridgeAccessConfigPresentationViewController.swift
@@ -23,7 +23,7 @@ class BridgeAccessConfigPresentationViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         usernameLabel?.text = bridgeAccesssConfig.username
@@ -36,9 +36,9 @@ class BridgeAccessConfigPresentationViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
-    @IBAction func okButtonTapped(sender: AnyObject) {
+    @IBAction func okButtonTapped(_ sender: AnyObject) {
     
-        (navigationController as! CreateBridgeAccessController).bridgeAccessCreated(bridgeAccesssConfig)
+        (navigationController as! CreateBridgeAccessController).bridgeAccessCreated(bridgeAccessConfig: bridgeAccesssConfig)
     }
 
     /*

--- a/SwiftyHue Example/BridgePushLinkViewController.swift
+++ b/SwiftyHue Example/BridgePushLinkViewController.swift
@@ -26,10 +26,10 @@ class BridgePushLinkViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        bridgeAuthenticator = BridgeAuthenticator(bridge: bridge, uniqueIdentifier: "swiftyhue#\(UIDevice.currentDevice().name)")
+        bridgeAuthenticator = BridgeAuthenticator(bridge: bridge, uniqueIdentifier: "swiftyhue#\(UIDevice.current.name)")
         bridgeAuthenticator.delegate = self;
         bridgeAuthenticator.start()
     }
@@ -45,9 +45,8 @@ class BridgePushLinkViewController: UIViewController {
     }
     */
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        
-        let destController = segue.destinationViewController as! BridgeAccessConfigPresentationViewController;
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let destController = segue.destination as! BridgeAccessConfigPresentationViewController;
         destController.bridgeAccesssConfig = bridgeAccessConfig;
     }
 
@@ -55,24 +54,24 @@ class BridgePushLinkViewController: UIViewController {
 
 extension BridgePushLinkViewController: BridgeAuthenticatorDelegate {
     
-    func bridgeAuthenticator(authenticator: BridgeAuthenticator, didFinishAuthentication username: String) {
+    func bridgeAuthenticator(_ authenticator: BridgeAuthenticator, didFinishAuthentication username: String) {
         
         self.bridgeAccessConfig = BridgeAccessConfig(bridgeId: "BridgeId", ipAddress: bridge.ip, username: username)
         
-        self.performSegueWithIdentifier("BridgeAccessConfigPresentationViewControllerSegue", sender: self)
+        self.performSegue(withIdentifier: "BridgeAccessConfigPresentationViewControllerSegue", sender: self)
     }
     
-    func bridgeAuthenticator(authenticator: BridgeAuthenticator, didFailWithError error: NSError) {
+    func bridgeAuthenticator(_ authenticator: BridgeAuthenticator, didFailWithError error: NSError) {
      
         print(error)
     }
     
     // you should now ask the user to press the link button
-    func bridgeAuthenticatorRequiresLinkButtonPress(authenticator: BridgeAuthenticator) {
+    func bridgeAuthenticatorRequiresLinkButtonPress(_ authenticator: BridgeAuthenticator) {
 
     }
     // user did not press the link button in time, you restart the process and try again
-    func bridgeAuthenticatorDidTimeout(authenticator: BridgeAuthenticator) {
+    func bridgeAuthenticatorDidTimeout(_ authenticator: BridgeAuthenticator) {
         
         print("timeout")
     }

--- a/SwiftyHue Example/BridgeResourceTableViewController.swift
+++ b/SwiftyHue Example/BridgeResourceTableViewController.swift
@@ -83,19 +83,19 @@ class BridgeResourceTableViewController: UITableViewController {
 
     // MARK: - Table view data source
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
+
         // #warning Incomplete implementation, return the number of sections
         return 1
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return bridgeResources.count
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+         return bridgeResources.count
     }
-
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("BridgeResourceTableViewCell", forIndexPath: indexPath)
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+ 
+        let cell = tableView.dequeueReusableCell(withIdentifier: "BridgeResourceTableViewCell", for: indexPath)
 
         let bridgeResource = self.bridgeResources[indexPath.row]
         

--- a/SwiftyHue Example/BridgeSelectionTableViewController.swift
+++ b/SwiftyHue Example/BridgeSelectionTableViewController.swift
@@ -17,57 +17,57 @@ class BridgeSelectionTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         
-        self.setBackgroundMessage("Searching Bridge")
+        self.setBackgroundMessage(message: "Searching Bridge")
         
     }
     
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         bridgeFinder.delegate = self;
         bridgeFinder.start()
     }
     
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         
         return 1
     }
     
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         
         return bridges?.count ?? 0
     }
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         let bridge = self.bridges![indexPath.row]
         
-        let cell = tableView.dequeueReusableCellWithIdentifier("BridgeCell", forIndexPath: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "BridgeCell", for: indexPath)
         cell.textLabel?.text = bridge.friendlyName
         
         return cell
     }
     
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
         selectedBridge = bridges![indexPath.row]
  
-        self.performSegueWithIdentifier("BridgePushLinkViewControllerSegue", sender: self)
+        performSegue(withIdentifier: "BridgePushLinkViewControllerSegue", sender: self)
     }
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
-        let destController = segue.destinationViewController as! BridgePushLinkViewController;
+        let destController = segue.destination as! BridgePushLinkViewController;
         destController.bridge = selectedBridge
     }
 }
 
 extension BridgeSelectionTableViewController: BridgeFinderDelegate {
     
-    func bridgeFinder(finder: BridgeFinder, didFinishWithResult bridges: [HueBridge]) {
+    func bridgeFinder(_ finder: BridgeFinder, didFinishWithResult bridges: [HueBridge]) {
      
         self.bridges = bridges;
-        self.setBackgroundMessage(nil)
+        self.setBackgroundMessage(message: nil)
         self.tableView.reloadData()
     }
 }

--- a/SwiftyHue Example/CreateBridgeAccessController.swift
+++ b/SwiftyHue Example/CreateBridgeAccessController.swift
@@ -20,7 +20,7 @@ public class CreateBridgeAccessController: UINavigationController {
     
     func bridgeAccessCreated(bridgeAccessConfig: BridgeAccessConfig) {
         
-        dismissViewControllerAnimated(true, completion: nil)
-        bridgeAccessCreationDelegate?.bridgeAccessCreated(bridgeAccessConfig)
+        dismiss(animated: true, completion: nil)
+        bridgeAccessCreationDelegate?.bridgeAccessCreated(bridgeAccessConfig: bridgeAccessConfig)
     }
 }

--- a/SwiftyHue Example/UITableViewController+Extensions.swift
+++ b/SwiftyHue Example/UITableViewController+Extensions.swift
@@ -16,17 +16,17 @@ extension UITableViewController {
             let messageLabel = UILabel()
             
             messageLabel.text = message
-            messageLabel.font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
-            messageLabel.textColor = UIColor.lightGrayColor()
-            messageLabel.textAlignment = .Center
+            messageLabel.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
+            messageLabel.textColor = UIColor.lightGray
+            messageLabel.textAlignment = .center
             messageLabel.sizeToFit()
             
             tableView.backgroundView = messageLabel
-            tableView.separatorStyle = .None
+            tableView.separatorStyle = .none
         }
         else {
             tableView.backgroundView = nil
-            tableView.separatorStyle = .SingleLine
+            tableView.separatorStyle = .singleLine
         }
     }
 }

--- a/SwiftyHue Example/ViewController.swift
+++ b/SwiftyHue Example/ViewController.swift
@@ -14,19 +14,19 @@ var swiftyHue: SwiftyHue = SwiftyHue();
 
 class ViewController: UIViewController, BridgeFinderDelegate, BridgeAuthenticatorDelegate {
     
-    private let bridgeAccessConfigUserDefaultsKey = "BridgeAccessConfig"
+    fileprivate let bridgeAccessConfigUserDefaultsKey = "BridgeAccessConfig"
     
-    private let bridgeFinder = BridgeFinder()
-    private var bridgeAuthenticator: BridgeAuthenticator?
+    fileprivate let bridgeFinder = BridgeFinder()
+    fileprivate var bridgeAuthenticator: BridgeAuthenticator?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         swiftyHue.enableLogging(true)
-        swiftyHue.setMinLevelForLogMessages(.Info)
+        swiftyHue.setMinLevelForLogMessages(.info)
     }
     
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         if let bridgeAccessConfig = readBridgeAccessConfig() {
@@ -35,10 +35,10 @@ class ViewController: UIViewController, BridgeFinderDelegate, BridgeAuthenticato
             
         } else {
            
-            var controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("CreateBridgeAccessController") as! CreateBridgeAccessController
+            var controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CreateBridgeAccessController") as! CreateBridgeAccessController
             controller.bridgeAccessCreationDelegate = self;
 
-            self.presentViewController(controller, animated: false, completion: nil)
+            self.present(controller, animated: false, completion: nil)
         }
 
     }
@@ -48,9 +48,9 @@ class ViewController: UIViewController, BridgeFinderDelegate, BridgeAuthenticato
         // Dispose of any resources that can be recreated.
     }
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        
-        let destController = segue.destinationViewController as! BridgeResourceTableViewController
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+                
+        let destController = segue.destination as! BridgeResourceTableViewController
         
         if segue.identifier == "LightsSegue" {
             
@@ -90,8 +90,8 @@ extension ViewController {
     
     func readBridgeAccessConfig() -> BridgeAccessConfig? {
         
-        let userDefaults = NSUserDefaults.standardUserDefaults()
-        let bridgeAccessConfigJSON = userDefaults.objectForKey(bridgeAccessConfigUserDefaultsKey) as? JSON
+        let userDefaults = UserDefaults.standard
+        let bridgeAccessConfigJSON = userDefaults.object(forKey: bridgeAccessConfigUserDefaultsKey) as? JSON
         
         var bridgeAccessConfig: BridgeAccessConfig?
         if let bridgeAccessConfigJSON = bridgeAccessConfigJSON {
@@ -104,9 +104,9 @@ extension ViewController {
     
     func writeBridgeAccessConfig(bridgeAccessConfig: BridgeAccessConfig) {
         
-        let userDefaults = NSUserDefaults.standardUserDefaults()
+        let userDefaults = UserDefaults.standard
         let bridgeAccessConfigJSON = bridgeAccessConfig.toJSON()
-        userDefaults.setObject(bridgeAccessConfigJSON, forKey: bridgeAccessConfigUserDefaultsKey)
+        userDefaults.set(bridgeAccessConfigJSON, forKey: bridgeAccessConfigUserDefaultsKey)
     }
 }
 
@@ -116,7 +116,7 @@ extension ViewController: CreateBridgeAccessControllerDelegate {
     
     func bridgeAccessCreated(bridgeAccessConfig: BridgeAccessConfig) {
         
-        writeBridgeAccessConfig(bridgeAccessConfig)
+        writeBridgeAccessConfig(bridgeAccessConfig: bridgeAccessConfig)
     }
 }
 
@@ -154,7 +154,7 @@ extension ViewController {
 //        
 //        beatManager.startHeartbeat()
 //                
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ViewController.lightChanged), name: ResourceCacheUpdateNotification.lightsUpdated.rawValue, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.lightChanged), name: NSNotification.Name(rawValue: ResourceCacheUpdateNotification.lightsUpdated.rawValue), object: nil)
         
         //        var lightState = LightState()
         //        lightState.on = true
@@ -229,7 +229,7 @@ extension ViewController {
     
     // MARK: - BridgeFinderDelegate
     
-    func bridgeFinder(finder: BridgeFinder, didFinishWithResult bridges: [HueBridge]) {
+    func bridgeFinder(_ finder: BridgeFinder, didFinishWithResult bridges: [HueBridge]) {
         print(bridges)
         guard let bridge = bridges.first else {
             return
@@ -242,19 +242,19 @@ extension ViewController {
     
     // MARK: - BridgeAuthenticatorDelegate
     
-    func bridgeAuthenticatorDidTimeout(authenticator: BridgeAuthenticator) {
+    func bridgeAuthenticatorDidTimeout(_ authenticator: BridgeAuthenticator) {
         print("Timeout")
     }
     
-    func bridgeAuthenticator(authenticator: BridgeAuthenticator, didFailWithError error: NSError) {
+    func bridgeAuthenticator(_ authenticator: BridgeAuthenticator, didFailWithError error: NSError) {
         print("Error while authenticating: \(error)")
     }
     
-    func bridgeAuthenticatorRequiresLinkButtonPress(authenticator: BridgeAuthenticator) {
+    func bridgeAuthenticatorRequiresLinkButtonPress(_ authenticator: BridgeAuthenticator) {
         print("Press link button")
     }
     
-    func bridgeAuthenticator(authenticator: BridgeAuthenticator, didFinishAuthentication username: String) {
+    func bridgeAuthenticator(_ authenticator: BridgeAuthenticator, didFinishAuthentication username: String) {
         print("Authenticated, hello \(username)")
     }
 }

--- a/SwiftyHue.xcodeproj/project.pbxproj
+++ b/SwiftyHue.xcodeproj/project.pbxproj
@@ -1883,6 +1883,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
@@ -1908,6 +1909,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;


### PR DESCRIPTION
- Updated dependencies 
- `createSceneWithName` now returns the completed scene id (since there's no other way to get it) which required a new type alias for the completion handler
- Added a way to overload the bridge heartbeat delegate so that I can deterministically get the latest scenes
- Changed the `Error` class to `HueError`, since calling it the Error class overwrote Apple's own Error class and had broken CoreBluetooth in weird ways.
- Added `updateLightStateInScene` to `bridgeSendAPI`
